### PR TITLE
Tests: Requirements: Initial Update

### DIFF
--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -52,7 +52,7 @@ ipython==8.4.0; python_version > '3.6'
 ipython==7.16.1; python_version <= '3.6'  # pyup: ignore
 
 # pandas also dropped support
-pandas==1.2.4; python_version > '3.6'
+pandas==1.4.3; python_version > '3.6'
 pandas==1.1.5; python_version <= '3.6'  # pyup: ignore
 
 # so did numpy

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -30,7 +30,7 @@ gevent==21.12.0
 pygments==2.12.0
 pyside2==5.15.2.1
 pyqt5==5.15.7
-pyqtwebengine==5.15.1
+pyqtwebengine==5.15.6
 python-dateutil==2.8.1
 pytz==2021.1
 requests==2.25.1

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -28,7 +28,7 @@ babel==2.10.3
 future==0.18.2
 gevent==21.12.0
 pygments==2.12.0
-pyside2==5.15.1
+pyside2==5.15.2.1
 pyqt5==5.15.1
 pyqtwebengine==5.15.1
 python-dateutil==2.8.1

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -33,7 +33,7 @@ pyqt5==5.15.7
 pyqtwebengine==5.15.6
 python-dateutil==2.8.2
 pytz==2022.1
-requests==2.25.1
+requests==2.28.1
 # simplejson is used for text_c_extension
 simplejson==3.17.2
 sphinx==2.4.4 # pyup: ignore

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -32,7 +32,7 @@ pyside2==5.15.2.1
 pyqt5==5.15.7
 pyqtwebengine==5.15.6
 python-dateutil==2.8.2
-pytz==2021.1
+pytz==2022.1
 requests==2.25.1
 # simplejson is used for text_c_extension
 simplejson==3.17.2

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -35,7 +35,7 @@ python-dateutil==2.8.2
 pytz==2022.1
 requests==2.28.1
 # simplejson is used for text_c_extension
-simplejson==3.17.2
+simplejson==3.17.6
 sphinx==2.4.4 # pyup: ignore
 # Required for test_namespace_package
 sqlalchemy==1.4.14

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -31,7 +31,7 @@ pygments==2.12.0
 pyside2==5.15.2.1
 pyqt5==5.15.7
 pyqtwebengine==5.15.6
-python-dateutil==2.8.1
+python-dateutil==2.8.2
 pytz==2021.1
 requests==2.25.1
 # simplejson is used for text_c_extension

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -29,7 +29,7 @@ future==0.18.2
 gevent==21.12.0
 pygments==2.12.0
 pyside2==5.15.2.1
-pyqt5==5.15.1
+pyqt5==5.15.7
 pyqtwebengine==5.15.1
 python-dateutil==2.8.1
 pytz==2021.1

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -38,7 +38,7 @@ requests==2.28.1
 simplejson==3.17.6
 sphinx==2.4.4 # pyup: ignore
 # Required for test_namespace_package
-sqlalchemy==1.4.14
+sqlalchemy==1.4.39
 zope.interface==5.4.0
 Pillow==8.2.0
 

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -27,7 +27,7 @@ keyring==19.2.0  # pyup: ignore
 babel==2.10.3
 future==0.18.2
 gevent==21.12.0
-pygments==2.9.0
+pygments==2.12.0
 pyside2==5.15.1
 pyqt5==5.15.1
 pyqtwebengine==5.15.1

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -26,7 +26,7 @@ keyring==19.2.0  # pyup: ignore
 # These packages work with no (known) issues.
 babel==2.10.3
 future==0.18.2
-gevent==21.1.2
+gevent==21.12.0
 pygments==2.9.0
 pyside2==5.15.1
 pyqt5==5.15.1

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -56,7 +56,7 @@ pandas==1.4.3; python_version > '3.6'
 pandas==1.1.5; python_version <= '3.6'  # pyup: ignore
 
 # so did numpy
-numpy==1.20.2; python_version > '3.6'
+numpy==1.23.1; python_version > '3.6'
 numpy==1.19.4; python_version <= '3.6'  # pyup: ignore
 
 # scipy too

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -48,7 +48,7 @@ Pillow==9.2.0
 
 # iPython 7.17 dropped support for python 3.6
 # https://ipython.readthedocs.io/en/stable/whatsnew/version7.html#ipython-7-17
-ipython==7.23.1; python_version > '3.6'
+ipython==8.4.0; python_version > '3.6'
 ipython==7.16.1; python_version <= '3.6'  # pyup: ignore
 
 # pandas also dropped support

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -64,7 +64,7 @@ scipy==1.8.1; python_version > '3.6'
 scipy==1.5.4; python_version <= '3.6'  # pyup: ignore
 
 # and matplotlib
-matplotlib==3.4.2; python_version > '3.6'
+matplotlib==3.5.2; python_version > '3.6'
 matplotlib==3.3.4; python_version <= '3.6'  # pyup: ignore
 
 # Install PyInstaller Hook Sample, to ensure that tests declared in

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -24,7 +24,7 @@ keyring==19.2.0  # pyup: ignore
 # Working
 # -------
 # These packages work with no (known) issues.
-babel==2.9.1
+babel==2.10.3
 future==0.18.2
 gevent==21.1.2
 pygments==2.9.0

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -40,7 +40,7 @@ sphinx==2.4.4 # pyup: ignore
 # Required for test_namespace_package
 sqlalchemy==1.4.39
 zope.interface==5.4.0
-Pillow==8.2.0
+Pillow==9.2.0
 
 
 # Python versions not supported / supported for older package versions

--- a/tests/requirements-libraries.txt
+++ b/tests/requirements-libraries.txt
@@ -60,7 +60,7 @@ numpy==1.23.1; python_version > '3.6'
 numpy==1.19.4; python_version <= '3.6'  # pyup: ignore
 
 # scipy too
-scipy==1.6.3; python_version > '3.6'
+scipy==1.8.1; python_version > '3.6'
 scipy==1.5.4; python_version <= '3.6'  # pyup: ignore
 
 # and matplotlib


### PR DESCRIPTION



### Update [babel](https://pypi.org/project/babel) from **2.9.1** to **2.10.3**.




### Update [gevent](https://pypi.org/project/gevent) from **21.1.2** to **21.12.0**.




### Update [pygments](https://pypi.org/project/pygments) from **2.9.0** to **2.12.0**.




### Update [pyside2](https://pypi.org/project/pyside2) from **5.15.1** to **5.15.2.1**.




### Update [pyqt5](https://pypi.org/project/pyqt5) from **5.15.1** to **5.15.7**.




### Update [pyqtwebengine](https://pypi.org/project/pyqtwebengine) from **5.15.1** to **5.15.6**.




### Update [python-dateutil](https://pypi.org/project/python-dateutil) from **2.8.1** to **2.8.2**.




### Update [pytz](https://pypi.org/project/pytz) from **2021.1** to **2022.1**.




### Update [requests](https://pypi.org/project/requests) from **2.25.1** to **2.28.1**.




### Update [simplejson](https://pypi.org/project/simplejson) from **3.17.2** to **3.17.6**.




### Update [sqlalchemy](https://pypi.org/project/sqlalchemy) from **1.4.14** to **1.4.39**.




### Update [Pillow](https://pypi.org/project/Pillow) from **8.2.0** to **9.2.0**.




### Update [ipython](https://pypi.org/project/ipython) from **7.23.1** to **8.4.0**.




### Update [pandas](https://pypi.org/project/pandas) from **1.2.4** to **1.4.3**.




### Update [numpy](https://pypi.org/project/numpy) from **1.20.2** to **1.23.1**.




### Update [scipy](https://pypi.org/project/scipy) from **1.6.3** to **1.8.1**.




### Update [matplotlib](https://pypi.org/project/matplotlib) from **3.4.2** to **3.5.2**.





---
*Running the bot with an API key allows it to query pyup.io's API for changelogs and insecure packages. This is highly recommended for production use. [Learn More](https://pyup.io/docs/api-key/)*
